### PR TITLE
RDEPEND xcb-proto moved from x11-proto to x11-base

### DIFF
--- a/x11-misc/polybar/polybar-9999.ebuild
+++ b/x11-misc/polybar/polybar-9999.ebuild
@@ -23,7 +23,7 @@ IUSE="+alsa i3 mpd curl network"
 RDEPEND="
         x11-libs/libxcb[xkb]
         x11-libs/cairo[xcb]
-        x11-proto/xcb-proto
+        x11-base/xcb-proto
         x11-libs/xcb-util-wm
         x11-libs/xcb-util-image
 


### PR DESCRIPTION
Gentoo Portage moved package xcb-proto from category x11-proto to x11-base a few days ago.

See 
https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=d420deeb520b7e598eba60f7d2cabd18ae161f7a
for details